### PR TITLE
add ability to set className on FluidGridItems

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-fluid-grid",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
       "docs"
     ]
   },
-  "version": "1.0.8",
+  "version": "1.0.9",
   "dependencies": {
     "detect-node": "^2.0.3"
   }

--- a/src/FluidGrid.js
+++ b/src/FluidGrid.js
@@ -118,12 +118,13 @@ class FluidGrid extends React.Component {
 
   renderChild (child, index) {
     const { columnWidth, gridWidth, gutterWidth, items, numberOfColumns } = this.state
-    const { transition } = this.props
+    const { itemClassName, transition } = this.props
     const registerItem = (element) => {
       this.items[index] = { element }
     }
     return (
       <FluidGridItem
+        className={itemClassName}
         columnWidth={columnWidth}
         gridWidth={gridWidth}
         gutterWidth={gutterWidth}
@@ -174,12 +175,14 @@ const styleStrategyShape = {
 FluidGrid.propTypes = {
   className: PropTypes.string,
   children: PropTypes.node,
+  itemClassName: PropTypes.string,
   styleStrategies: PropTypes.arrayOf(PropTypes.shape(styleStrategyShape)),
   transition: PropTypes.string
 }
 
 FluidGrid.defaultProps = {
   className: '',
+  itemClassName: '',
   styleStrategies: defaultStyleStrategies
 }
 

--- a/src/FluidGridItem/FluidGridItem.jsx
+++ b/src/FluidGridItem/FluidGridItem.jsx
@@ -5,6 +5,7 @@ import getItemStyles from '../helpers/getItemStyles'
 
 function FluidGridItem ({
   children,
+  className,
   columnWidth,
   gridWidth,
   gutterWidth,
@@ -27,6 +28,7 @@ function FluidGridItem ({
   })
   return (
     <div
+      className={className}
       ref={registerItem}
       style={style}
     >
@@ -39,6 +41,7 @@ function FluidGridItem ({
 
 FluidGridItem.propTypes = {
   children: PropTypes.node,
+  className: PropTypes.string,
   columnWidth: PropTypes.number,
   gridWidth: PropTypes.number,
   gutterWidth: PropTypes.number,
@@ -51,6 +54,7 @@ FluidGridItem.propTypes = {
 }
 
 FluidGridItem.defaultProps = {
+  className: '',
   transition: 'top 200ms ease-in-out, left 200ms ease-in-out, width 200ms ease-in-out'
 }
 


### PR DESCRIPTION
Can we add the ability to set className on the FluidGridItems?  I would like to be able to apply CSS rules to the individual items without having to use a div selector.