### PR TITLE
Fixed removing child element causing error

### DIFF
--- a/src/FluidGrid.js
+++ b/src/FluidGrid.js
@@ -56,7 +56,9 @@ class FluidGrid extends React.Component {
   }
 
   arrangeItems () {
-    Object.values(this.items).forEach(this.pushToShortestColumn)
+    Object.values(this.items)
+    .filter(({element}) => element)
+    .forEach(this.pushToShortestColumn);
   }
 
   pushToShortestColumn (item) {


### PR DESCRIPTION
Fixes issue #8.

When removing a child element, an error was thrown saying `clientHeight` was `undefined` on `item.element`. The solution is to filter out items with a `null` element.

This issue is caused by `this.items` having the previous children after `componentDidUpdate` and not the updated children from `this.props.children`. This is a stop-gap fix until a real fix can be made which re-computes the children off `this.props.children` in `this.updateLayout`.

I understand the code styling might not match up with what you'd like so feel free to edit it or suggest changes for how you'd like it to look.